### PR TITLE
Add ability to parse into any dict -- OrderedDict works

### DIFF
--- a/pytoml/writer.py
+++ b/pytoml/writer.py
@@ -91,9 +91,15 @@ def _format_value(v):
 def dump(fout, obj, sort_keys=False):
     tables = [((), obj, False)]
 
+    def table_cmp(a, b):
+        """don't re-order arrays"""
+        if a[2] and b[2]:   # if both are arrays
+            return 0        # don't re-order
+        return cmp(a[0], b[0])
+
     while tables:
         if sort_keys:
-            tables.sort(key=lambda tup: tup[0], reverse=True)
+            tables.sort(cmp=table_cmp, reverse=True)
         name, table, is_array = tables.pop()
         if name:
             section_name = '.'.join(_escape_id(c) for c in name)
@@ -102,7 +108,10 @@ def dump(fout, obj, sort_keys=False):
             else:
                 fout.write('[{0}]\n'.format(section_name))
 
-        table_keys = sorted(table.keys()) if sort_keys else table.keys()
+        if sort_keys and not is_array:
+            table_keys = sorted(table.keys())
+        else:
+            table_keys = table.keys()
         for k in table_keys:
             v = table[k]
             if isinstance(v, dict):

--- a/test/test.py
+++ b/test/test.py
@@ -40,7 +40,9 @@ def adjust_bench(v):
 def _main():
     ap = argparse.ArgumentParser()
     ap.add_argument('-d', '--dir', action='append')
+    ap.add_argument('-s', '--sort-keys', action='store_true')
     ap.add_argument('testcase', nargs='*')
+    ap.set_defaults(sort_keys=False)
     args = ap.parse_args()
 
     if not args.dir:
@@ -69,7 +71,7 @@ def _main():
                     parsed = None
                     parse_error = sys.exc_info()
                 else:
-                    dumped = toml.dumps(parsed)
+                    dumped = toml.dumps(parsed, sort_keys=args.sort_keys)
                     parsed2 = toml.loads(dumped)
                     if parsed != parsed2:
                         failed.append((fname, parsed, parsed2, None))

--- a/test/test.py
+++ b/test/test.py
@@ -41,12 +41,25 @@ def _main():
     ap = argparse.ArgumentParser()
     ap.add_argument('-d', '--dir', action='append')
     ap.add_argument('-s', '--sort-keys', action='store_true')
+    ap.add_argument('--dict-type')
     ap.add_argument('testcase', nargs='*')
     ap.set_defaults(sort_keys=False)
     args = ap.parse_args()
 
     if not args.dir:
         args.dir = [os.path.join(os.path.split(__file__)[0], 'toml-test/tests')]
+
+    dict_type = dict
+    if args.dict_type:
+        try:
+            parts = args.dict_type.split('.')
+            module = __import__(".".join(parts[:-1]))
+            for part in args.dict_type.split(".")[1:]:
+                module = getattr(module, part)
+            dict_type = module
+        except:
+            print('error: unable to load dict_type: {0}'.format(args.dict_type))
+            return 2
 
     succeeded = []
     failed = []
@@ -66,19 +79,20 @@ def _main():
                 parse_error = None
                 try:
                     with open(os.path.join(top, fname), 'rb') as fin:
-                        parsed = toml.load(fin)
+                        parsed = toml.load(fin, dict_type=dict_type)
                 except toml.TomlError:
                     parsed = None
                     parse_error = sys.exc_info()
                 else:
                     dumped = toml.dumps(parsed, sort_keys=args.sort_keys)
-                    parsed2 = toml.loads(dumped)
+                    parsed2 = toml.loads(dumped, dict_type=dict_type)
                     if parsed != parsed2:
                         failed.append((fname, parsed, parsed2, None))
                         continue
 
                     with open(os.path.join(top, fname), 'rb') as fin:
-                        parsed = toml.load(fin, translate=_testbench_literal)
+                        parsed = toml.load(fin, translate=_testbench_literal,
+                                dict_type=dict_type)
 
                 try:
                     with io.open(os.path.join(top, fname[:-5] + '.json'), 'rt', encoding='utf-8') as fin:


### PR DESCRIPTION
Rounds trips cleanly as:

``` PYTHON
import pytoml as toml
from collections import OrderedDict

with open("/Users/rbrase/config.toml") as f:
    print toml.dumps(toml.load(f, dict_type=OrderedDict))
```

Just one blank line added

```
$ python load-dump.py | diff ~/config.toml -
70a71
>
``
```
